### PR TITLE
Adding Docker build/run process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+ARG BUILD_PLATFORM=linux/arm64/v8
+FROM --platform=${BUILD_PLATFORM} python:3.12.11-trixie
+
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Install Node & NPM
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+RUN nvm install v22.18.0
+RUN npm install -g npm@11.5.2
+
+# Add files
+RUN mkdir -p /root/iam-dangerous-actions/
+WORKDIR /root/iam-dangerous-actions/
+ADD . .

--- a/scripts/all-actions-for-all-roles-mac.sh
+++ b/scripts/all-actions-for-all-roles-mac.sh
@@ -1,8 +1,7 @@
+#!/bin/bash
+
 ## Author: David Kerber, with some AI code changes.
 ## Usage: sh all-actions-for-all-roles-mac.sh 
-
-
-#!/bin/bash
 
 # Prompt for AWS Account Number
 read -p "Enter the AWS Account Number: " account

--- a/scripts/all-actions-for-all-roles.sh
+++ b/scripts/all-actions-for-all-roles.sh
@@ -1,8 +1,7 @@
+#!/bin/sh
+
 ## Author: David Kerber, with AI code enhancements for processing and error handling.
 ## Usage: sh all-actions-for-all-roles.sh 
-
-
-#!/bin/sh
 
 # Prompt for AWS Account Number
 read -p "Enter the AWS Account Number: " account


### PR DESCRIPTION
Build with ```docker build -t dangerous .```
Run with ```docker run --rm -it dangerous:latest scripts/all-actions-for-all-roles-mac.sh```

During testing i noticed the two shell scripts under scripts/ had their shebang line `#!/bin/bash` not at the beginning of the file - it's a Unix specification which is required when the file is called.

I was seeing this error from inside the container ```exec scripts/all-actions-for-all-roles-mac.sh: exec format error```

You might need to change the $BUILD_PLATFORM to match your local env for running the container. Or update the process to use buildx and target all platforms... it depends on what the end-goal of this container is.
